### PR TITLE
Updated `_parsePath` to handle query strings better.

### DIFF
--- a/src/soundjs/Sound.js
+++ b/src/soundjs/Sound.js
@@ -380,13 +380,14 @@ this.createjs = this.createjs || {};
 
 	/**
 	 * The RegExp pattern used to parse file URIs. This supports simple file names, as well as full domain URIs with
-	 * query strings. The resulting match is: protocol:$1 domain:$2 path:$3 file:$4 extension:$5 query:$6.
+	 * query strings. The resulting match is: protocol:$1 domain:$2 path:$3 file:$4 extension:$5 query:$6 query-file:$7 query-extension:$8.
+	 * "query-file" and "query-extension" are provided if the source file is defined by a query string.
 	 * @property FILE_PATTERN
 	 * @type {RegExp}
 	 * @static
 	 * @protected
 	 */
-	s.FILE_PATTERN = /^(?:(\w+:)\/{2}(\w+(?:\.\w+)*\/?))?([/.]*?(?:[^?]+)?\/)?((?:[^/?]+)\.(\w+))(?:\?(\S+)?)?$/;
+	s.FILE_PATTERN = /^(?:(\w+:)\/{2}(\w+(?:\.\w+)*\/?))?([\/.]*?(?:[^?]+)?\/)?(?:((?:[^\/?]+)\.(\w+))|(?:[^\/?]+))(?:\?((?:(?:[^&]*?[\/=])?(?:((?:(?:[^\/?&=]+)\.(\w+)))\S*?)|\S+))?)?$/;
 
 
 // Class Public properties
@@ -1191,23 +1192,22 @@ this.createjs = this.createjs || {};
 	s._parsePath = function (value) {
 		if (typeof(value) != "string") {value = value.toString();}
 
-		/*var match = value.match(s.FILE_PATTERN);
-		if (match == null) {return false;}
-
-		var name = match[4];
-		var ext = match[5];*/
 		//Changed how extensions and filenames are grabbed from the url to add simple support for
 		//urls that use php services & query string params to specify the file
-		var ext, name, origExt;
-		if(value.indexOf(".") >= 0)
-		{
-			ext = value.substr(value.lastIndexOf(".")+1);
-			if(ext.indexOf("?") > 0)
-				ext = ext.substring(0, ext.indexOf("?"));
-			name = value.substring(0, value.lastIndexOf("."));
-			if(name.indexOf("/") >= 0)
-				name = name.substr(name.lastIndexOf("/")+1);
-			origExt = ext;
+		var match = value.match(s.FILE_PATTERN);
+		if (match === null) {return false;}
+
+		var name = '';
+		var ext = '';
+		var origExt = '';
+		if (s.SUPPORTED_EXTENSIONS.indexOf(match[5]) >= 0) {
+			name = match[4];
+			origExt = ext = match[5];
+		} else if (s.SUPPORTED_EXTENSIONS.indexOf(match[8]) >= 0) {
+			name = match[7];
+			origExt = ext = match[8];
+		} else {
+			return null;
 		}
 
 		var c = s.capabilities;


### PR DESCRIPTION
Per [this discussion](https://github.com/SpringRoll/SpringRoll/issues/72), I've updated the SoundJS `_parsePath` method to handle query string variations better.

In most cases, the [new regex](https://regexper.com/#%5E%28%3F%3A%28%5Cw%2B%3A%29%5C%2F%7B2%7D%28%5Cw%2B%28%3F%3A%5C.%5Cw%2B%29*%5C%2F%3F%29%29%3F%28%5B%5C%2F.%5D*%3F%28%3F%3A%5B%5E%3F%5D%2B%29%3F%5C%2F%29%3F%28%3F%3A%28%28%3F%3A%5B%5E%5C%2F%3F%5D%2B%29%5C.%28%5Cw%2B%29%29%7C%28%3F%3A%5B%5E%5C%2F%3F%5D%2B%29%29%28%3F%3A%5C%3F%28%28%3F%3A%28%3F%3A%5B%5E%26%5D*%3F%5B%5C%2F%3D%5D%29%3F%28%3F%3A%28%28%3F%3A%28%3F%3A%5B%5E%5C%2F%3F%26%3D%5D%2B%29%5C.%28%5Cw%2B%29%29%29%5CS*%3F%29%7C%5CS%2B%29%29%3F%29%3F%24) can find the extension for a sound file whether it's a direct link or part of a query string.

Below I've listed a wide assortment of urls the updated method can handle, including the three properties it outputs.

| Path | name | src | extension |
| --- | --- | --- | --- |
| music.mp3 | "music.mp3" | "music.mp3" | "mp3" |
| ../music.mp3 | "music.mp3" | "../music.mp3" | "mp3" |
| ../sub/dir/music.mp3 | "music.mp3" | "../sub/dir/music.mp3" | "mp3" |
| /from/root/music.mp3 | "music.mp3" | "/from/root/music.mp3" | "mp3" |
| http<span>://</span>web.site/sub/dir/music.mp3 | "music.mp3" | "http<span>://</span>web.site/sub/dir/music.mp3" | "mp3" |
| music.mp3?v=1.1.1 | "music.mp3" | "music.mp3?v=1.1.1" | "mp3" |
| ../sub/dir/music.mp3?with=query-parameters | "music.mp3" | "../sub/dir/music.mp3?with=query-parameters" | "mp3" |
| music.mp3?with/confusing/filename.ogg | "music.mp3" | "music.mp3?with/confusing/filename.ogg" | "mp3" |
| audio?music.mp3 | "music.mp3" | "audio?music.mp3" | "mp3" |
| audio.php | null | null | null |
| audio.php?music.mp3 | "music.mp3" | "audio.php?music.mp3" | "mp3" |
| ../sub/dir/audio?music.mp3 | "music.mp3" | "../sub/dir/audio?music.mp3" | "mp3" |
| /from/root/audio?music.mp3 | "music.mp3" | "/from/root/audio?music.mp3" | "mp3" |
| http<span>://</span>web.site/sub/dir/audio.php?music.mp3 | "music.mp3" | "http<span>://</span>web.site/sub/dir/audio.php?music.mp3" | "mp3" |
| audio?../sub/dir/music.mp3 | "music.mp3" | "audio?../sub/dir/music.mp3" | "mp3" |
| audio?music.mp3&v=1.1.1 | "music.mp3" | "audio?music.mp3&v=1.1.1" | "mp3" |
| audio?file=music.mp3&v=1.1.1 | "music.mp3" | "audio?file=music.mp3&v=1.1.1" | "mp3" |
| audio?v=1.1.1&file=music.mp3 | null | null | null |
| audio?big-parameter_name=/big/file/name/music.mp3&v=1.1.1 | "music.mp3" | "audio?big-parameter_name=/big/file/name/music.mp3&v=1.1.1" | "mp3" |
| unsupported/music.wma?with=OGGalternative | "music.wma" | "unsupported/music.ogg?with=OGGalternative" | "ogg" |

Two fail: one has no audio file type specified, and the other fails since the method is only checking the first valid parameter of the query string for a file type. It's checking against the first parameter's "1.1.1", but I'm not certain of a concise and foolproof way to fix the general case for an indeterminate set of parameters.

Let me know what you think!
